### PR TITLE
Fix swap date time settings

### DIFF
--- a/app/src/main/java/awais/instagrabber/dialogs/TimeSettingsDialog.java
+++ b/app/src/main/java/awais/instagrabber/dialogs/TimeSettingsDialog.java
@@ -34,15 +34,18 @@ public final class TimeSettingsDialog extends DialogFragment implements AdapterV
     private boolean customDateTimeFormatEnabled;
     private String customDateTimeFormat;
     private String dateTimeSelection;
+    private final boolean swapDateTimeEnabled;
     private final OnConfirmListener onConfirmListener;
 
     public TimeSettingsDialog(final boolean customDateTimeFormatEnabled,
                               final String customDateTimeFormat,
                               final String dateTimeSelection,
+                              final boolean swapDateTimeEnabled,
                               final OnConfirmListener onConfirmListener) {
         this.customDateTimeFormatEnabled = customDateTimeFormatEnabled;
         this.customDateTimeFormat = customDateTimeFormat;
         this.dateTimeSelection = dateTimeSelection;
+        this.swapDateTimeEnabled = swapDateTimeEnabled;
         this.onConfirmListener = onConfirmListener;
         final Calendar instance = GregorianCalendar.getInstance();
         instance.set(2020, 5, 22, 8, 17, 13);
@@ -55,6 +58,7 @@ public final class TimeSettingsDialog extends DialogFragment implements AdapterV
 
         timeSettingsBinding.cbCustomFormat.setOnCheckedChangeListener(this);
         timeSettingsBinding.cbCustomFormat.setChecked(customDateTimeFormatEnabled);
+        timeSettingsBinding.cbSwapTimeDate.setChecked(swapDateTimeEnabled);
         timeSettingsBinding.etCustomFormat.setText(customDateTimeFormat);
 
         final String[] dateTimeFormat = dateTimeSelection.split(";"); // output = time;separator;date
@@ -146,13 +150,15 @@ public final class TimeSettingsDialog extends DialogFragment implements AdapterV
         if (v == timeSettingsBinding.btnConfirm) {
             final Editable etCustomFormatText = timeSettingsBinding.etCustomFormat.getText();
             if (onConfirmListener != null) {
-                onConfirmListener.onConfirm(timeSettingsBinding.cbCustomFormat.isChecked(),
+                onConfirmListener.onConfirm(
+                        timeSettingsBinding.cbCustomFormat.isChecked(),
                         etCustomFormatText == null ? null : etCustomFormatText.toString(),
                         timeSettingsBinding.spTimeFormat.getSelectedItemPosition(),
                         timeSettingsBinding.spSeparator.getSelectedItemPosition(),
                         timeSettingsBinding.spDateFormat.getSelectedItemPosition(),
                         selectedFormat,
-                        currentFormat);
+                        currentFormat,
+                        timeSettingsBinding.cbSwapTimeDate.isChecked());
             }
             dismiss();
         } else if (v == timeSettingsBinding.btnInfo) {
@@ -167,7 +173,10 @@ public final class TimeSettingsDialog extends DialogFragment implements AdapterV
                        String formatSelection,
                        int spTimeFormatSelectedItemPosition,
                        int spSeparatorSelectedItemPosition,
-                       int spDateFormatSelectedItemPosition, final String selectedFormat, final SimpleDateFormat currentFormat);
+                       int spDateFormatSelectedItemPosition,
+                       final String selectedFormat,
+                       final SimpleDateFormat currentFormat,
+                       final boolean swapDateTime);
     }
 
     @Override

--- a/app/src/main/java/awais/instagrabber/dialogs/TimeSettingsDialog.java
+++ b/app/src/main/java/awais/instagrabber/dialogs/TimeSettingsDialog.java
@@ -86,11 +86,12 @@ public final class TimeSettingsDialog extends DialogFragment implements AdapterV
             final String timeStr = String.valueOf(timeSettingsBinding.spTimeFormat.getSelectedItem());
             final String dateStr = String.valueOf(timeSettingsBinding.spDateFormat.getSelectedItem());
 
-            final boolean isSwapTime = !timeSettingsBinding.cbSwapTimeDate.isChecked();
+            final boolean isSwapTime = timeSettingsBinding.cbSwapTimeDate.isChecked();
+            final boolean isBlankSeparator = timeSettingsBinding.spSeparator.getSelectedItemPosition() <= 0;
 
-            selectedFormat = (isSwapTime ? timeStr : dateStr)
-                    + (TextUtils.isEmpty(sepStr) || timeSettingsBinding.spSeparator.getSelectedItemPosition() == 0 ? " " : " '" + sepStr + "' ")
-                    + (isSwapTime ? dateStr : timeStr);
+            selectedFormat = (isSwapTime ? dateStr : timeStr)
+                    + (isBlankSeparator ? " " : " '" + sepStr + "' ")
+                    + (isSwapTime ? timeStr : dateStr);
 
             timeSettingsBinding.btnConfirm.setEnabled(true);
             currentFormat = new SimpleDateFormat(selectedFormat, LocaleUtils.getCurrentLocale());

--- a/app/src/main/java/awais/instagrabber/fragments/settings/SettingsPreferencesFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/settings/SettingsPreferencesFragment.java
@@ -284,12 +284,15 @@ public class SettingsPreferencesFragment extends BasePreferencesFragment {
                     settingsHelper.getBoolean(Constants.CUSTOM_DATE_TIME_FORMAT_ENABLED),
                     settingsHelper.getString(Constants.CUSTOM_DATE_TIME_FORMAT),
                     settingsHelper.getString(Constants.DATE_TIME_SELECTION),
+                    settingsHelper.getBoolean(Constants.SWAP_DATE_TIME_FORMAT_ENABLED),
                     (isCustomFormat,
                      formatSelection,
                      spTimeFormatSelectedItemPosition,
                      spSeparatorSelectedItemPosition,
                      spDateFormatSelectedItemPosition,
-                     selectedFormat, currentFormat) -> {
+                     selectedFormat,
+                     currentFormat,
+                     swapDateTime) -> {
                         if (isCustomFormat) {
                             settingsHelper.putString(Constants.CUSTOM_DATE_TIME_FORMAT, formatSelection);
                         } else {
@@ -300,6 +303,7 @@ public class SettingsPreferencesFragment extends BasePreferencesFragment {
                             settingsHelper.putString(Constants.DATE_TIME_SELECTION, formatSelectionUpdated);
                         }
                         settingsHelper.putBoolean(Constants.CUSTOM_DATE_TIME_FORMAT_ENABLED, isCustomFormat);
+                        settingsHelper.putBoolean(Constants.SWAP_DATE_TIME_FORMAT_ENABLED, swapDateTime);
                         Utils.datetimeParser = (SimpleDateFormat) currentFormat.clone();
                         preference.setSummary(Utils.datetimeParser.format(new Date()));
                     }

--- a/app/src/main/java/awais/instagrabber/utils/Constants.java
+++ b/app/src/main/java/awais/instagrabber/utils/Constants.java
@@ -19,6 +19,7 @@ public final class Constants {
     public static final String AUTOLOAD_POSTS = "autoload_posts";
     public static final String SHOW_FEED = "show_feed";
     public static final String CUSTOM_DATE_TIME_FORMAT_ENABLED = "data_time_custom_enabled";
+    public static final String SWAP_DATE_TIME_FORMAT_ENABLED = "swap_date_time_enabled";
     public static final String MARK_AS_SEEN = "mark_as_seen";
     public static final String DM_MARK_AS_SEEN = "dm_mark_as_seen";
     public static final String INSTADP = "instadp";

--- a/app/src/main/java/awais/instagrabber/utils/SettingsHelper.java
+++ b/app/src/main/java/awais/instagrabber/utils/SettingsHelper.java
@@ -34,6 +34,7 @@ import static awais.instagrabber.utils.Constants.PREV_INSTALL_VERSION;
 import static awais.instagrabber.utils.Constants.SHOW_QUICK_ACCESS_DIALOG;
 import static awais.instagrabber.utils.Constants.SKIPPED_VERSION;
 import static awais.instagrabber.utils.Constants.STORY_VIEWER;
+import static awais.instagrabber.utils.Constants.SWAP_DATE_TIME_FORMAT_ENABLED;
 
 public final class SettingsHelper {
     private final SharedPreferences sharedPreferences;
@@ -118,7 +119,7 @@ public final class SettingsHelper {
 
     @StringDef({DOWNLOAD_USER_FOLDER, FOLDER_SAVE_TO, AUTOPLAY_VIDEOS, SHOW_QUICK_ACCESS_DIALOG, MUTED_VIDEOS,
                        AUTOLOAD_POSTS, CUSTOM_DATE_TIME_FORMAT_ENABLED, MARK_AS_SEEN, DM_MARK_AS_SEEN, INSTADP,
-                       CHECK_ACTIVITY, CHECK_UPDATES})
+                       CHECK_ACTIVITY, CHECK_UPDATES, SWAP_DATE_TIME_FORMAT_ENABLED})
     public @interface BooleanSettings {}
 
     @StringDef({PREV_INSTALL_VERSION})


### PR DESCRIPTION
Currently, if the user checks the option "Swap time and date positions",
leaves the settings modal and returns to it, the option will be
unchecked, even though the date and time are, indeed, swapped.

This saves the value of the "Swap time and date positions" option so
that it will match whatever state the user selected last.

Fixes: #165