### PR TITLE
Improve CookieUtils

### DIFF
--- a/app/src/main/java/awais/instagrabber/utils/CookieUtils.java
+++ b/app/src/main/java/awais/instagrabber/utils/CookieUtils.java
@@ -10,6 +10,8 @@ import java.net.CookieStore;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 
 import awais.instagrabber.BuildConfig;
 import awaisomereport.LogCollector;
@@ -74,79 +76,40 @@ public final class CookieUtils {
 
     @Nullable
     public static String getCookie(@Nullable final String webViewUrl) {
-        int lastLongestCookieLength = 0;
-        String mainCookie = null;
+        final List<String> domains = Arrays.asList(
+                "https://instagram.com",
+                "https://instagram.com/",
+                "http://instagram.com",
+                "http://instagram.com",
+                "https://www.instagram.com",
+                "https://www.instagram.com/",
+                "http://www.instagram.com",
+                "http://www.instagram.com/"
+        );
 
-        String cookie;
         if (!TextUtils.isEmpty(webViewUrl)) {
-            cookie = COOKIE_MANAGER.getCookie(webViewUrl);
+            domains.add(0, webViewUrl);
+        }
+
+        return getLongestCookie(domains);
+    }
+
+    @Nullable
+    private static String getLongestCookie(final List<String> domains) {
+        int longestLength = 0;
+        String longestCookie = null;
+
+        for (final String domain : domains) {
+            final String cookie = COOKIE_MANAGER.getCookie(domain);
             if (cookie != null) {
-                final int cookieLen = cookie.length();
-                if (cookieLen > lastLongestCookieLength) {
-                    mainCookie = cookie;
-                    lastLongestCookieLength = cookieLen;
+                final int cookieLength = cookie.length();
+                if (cookieLength > longestLength) {
+                    longestCookie = cookie;
+                    longestLength = cookieLength;
                 }
             }
         }
-        cookie = COOKIE_MANAGER.getCookie("https://instagram.com");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("https://instagram.com/");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("http://instagram.com");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("http://instagram.com/");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("https://www.instagram.com");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("https://www.instagram.com/");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("http://www.instagram.com");
-        if (cookie != null) {
-            final int cookieLen = cookie.length();
-            if (cookieLen > lastLongestCookieLength) {
-                mainCookie = cookie;
-                lastLongestCookieLength = cookieLen;
-            }
-        }
-        cookie = COOKIE_MANAGER.getCookie("http://www.instagram.com/");
-        if (cookie != null && cookie.length() > lastLongestCookieLength) mainCookie = cookie;
 
-        return mainCookie;
+        return longestCookie;
     }
 }

--- a/app/src/main/java/awais/instagrabber/utils/CookieUtils.java
+++ b/app/src/main/java/awais/instagrabber/utils/CookieUtils.java
@@ -12,6 +12,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import awais.instagrabber.BuildConfig;
 import awaisomereport.LogCollector;
@@ -56,22 +58,23 @@ public final class CookieUtils {
     }
 
     @Nullable
-    public static String getUserIdFromCookie(final String cookie) {
-        if (!TextUtils.isEmpty(cookie)) {
-            final int uidIndex = cookie.indexOf("ds_user_id=");
-            if (uidIndex > 0) {
-                String uid = cookie.split("ds_user_id=")[1].split(";")[0];
-                return !TextUtils.isEmpty(uid) ? uid : null;
-            }
-        }
-        return null;
+    public static String getUserIdFromCookie(final String cookies) {
+        return getCookieValue(cookies, "ds_user_id");
     }
 
-    public static String getCsrfTokenFromCookie(final String cookie) {
-        if (cookie == null) {
-            return null;
+    @Nullable
+    public static String getCsrfTokenFromCookie(final String cookies) {
+        return getCookieValue(cookies, "csrftoken");
+    }
+
+    @Nullable
+    private static String getCookieValue(final String cookies, final String name) {
+        final Pattern pattern = Pattern.compile(name + "=(.+?);");
+        final Matcher matcher = pattern.matcher(cookies);
+        if (matcher.find()) {
+            return matcher.group(1);
         }
-        return cookie.split("csrftoken=")[1].split(";")[0];
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
Currently, trying to get a `csrftoken` from an empty cookie string will
crash the application.

This creates a helper method to extract a cookie value given a cookie
name by pattern matching on the cookie string and returning the value
if one is found.