### PR TITLE
Add a setting to control showing/hidden the post label per default

### DIFF
--- a/app/src/main/java/awais/instagrabber/fragments/PostViewV2Fragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/PostViewV2Fragment.java
@@ -242,6 +242,8 @@ public class PostViewV2Fragment extends SharedElementTransitionDialogFragment {
         if (feedModel.getItemType() == MediaItemType.MEDIA_TYPE_SLIDER) {
             sliderPosition = arguments.getInt(ARG_SLIDER_POSITION, 0);
         }
+        captionState = settingsHelper.getBoolean(Constants.SHOW_CAPTIONS) ?
+                BottomSheetBehavior.STATE_COLLAPSED : BottomSheetBehavior.STATE_HIDDEN;
     }
 
     @Nullable
@@ -384,7 +386,7 @@ public class PostViewV2Fragment extends SharedElementTransitionDialogFragment {
                                                                                 ViewGroup.LayoutParams.MATCH_PARENT));
             binding.postImage.requestLayout();
             if (bottomSheetBehavior != null) {
-                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                bottomSheetBehavior.setState(captionState);
             }
             return;
         }
@@ -393,7 +395,7 @@ public class PostViewV2Fragment extends SharedElementTransitionDialogFragment {
                                                                                    ViewGroup.LayoutParams.MATCH_PARENT));
             binding.sliderParent.requestLayout();
             if (bottomSheetBehavior != null) {
-                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                bottomSheetBehavior.setState(captionState);
             }
             return;
         }
@@ -404,7 +406,7 @@ public class PostViewV2Fragment extends SharedElementTransitionDialogFragment {
             binding.videoPost.thumbnailParent.setLayoutParams(params);
             binding.videoPost.thumbnailParent.requestLayout();
             if (bottomSheetBehavior != null) {
-                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                bottomSheetBehavior.setState(captionState);
             }
         }
     }
@@ -846,7 +848,7 @@ public class PostViewV2Fragment extends SharedElementTransitionDialogFragment {
                 public void onGlobalLayout() {
                     binding.getRoot().getViewTreeObserver().removeOnGlobalLayoutListener(this);
                     if (bottomSheetBehavior == null) return;
-                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+                    bottomSheetBehavior.setState(captionState);
                 }
             });
         }

--- a/app/src/main/java/awais/instagrabber/fragments/settings/SettingsPreferencesFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/settings/SettingsPreferencesFragment.java
@@ -52,6 +52,7 @@ public class SettingsPreferencesFragment extends BasePreferencesFragment {
         generalCategory.addPreference(getUpdateCheckPreference());
         // generalCategory.addPreference(getAutoPlayVideosPreference());
         generalCategory.addPreference(getAlwaysMuteVideosPreference());
+        generalCategory.addPreference(getShowCaptionPreference());
 
         // screen.addPreference(getDivider(context));
         // final PreferenceCategory themeCategory = new PreferenceCategory(context);
@@ -200,6 +201,17 @@ public class SettingsPreferencesFragment extends BasePreferencesFragment {
         final SwitchPreferenceCompat preference = new SwitchPreferenceCompat(context);
         preference.setKey(Constants.MUTED_VIDEOS);
         preference.setTitle(R.string.post_viewer_muted_autoplay);
+        preference.setIconSpaceReserved(false);
+        return preference;
+    }
+
+    private Preference getShowCaptionPreference() {
+        final Context context = getContext();
+        if (context == null) return null;
+        final SwitchPreferenceCompat preference = new SwitchPreferenceCompat(context);
+        preference.setKey(Constants.SHOW_CAPTIONS);
+        preference.setDefaultValue(true);
+        preference.setTitle(R.string.post_viewer_show_captions);
         preference.setIconSpaceReserved(false);
         return preference;
     }

--- a/app/src/main/java/awais/instagrabber/utils/Constants.java
+++ b/app/src/main/java/awais/instagrabber/utils/Constants.java
@@ -17,6 +17,7 @@ public final class Constants {
     public static final String FOLDER_SAVE_TO = "saved_to";
     public static final String AUTOPLAY_VIDEOS = "autoplay_videos";
     public static final String MUTED_VIDEOS = "muted_videos";
+    public static final String SHOW_CAPTIONS = "show_captions";
     public static final String CUSTOM_DATE_TIME_FORMAT_ENABLED = "data_time_custom_enabled";
     public static final String SWAP_DATE_TIME_FORMAT_ENABLED = "swap_date_time_enabled";
     public static final String MARK_AS_SEEN = "mark_as_seen";

--- a/app/src/main/java/awais/instagrabber/utils/SettingsHelper.java
+++ b/app/src/main/java/awais/instagrabber/utils/SettingsHelper.java
@@ -37,6 +37,7 @@ import static awais.instagrabber.utils.Constants.PREF_SAVED_POSTS_LAYOUT;
 import static awais.instagrabber.utils.Constants.PREF_TAGGED_POSTS_LAYOUT;
 import static awais.instagrabber.utils.Constants.PREF_TOPIC_POSTS_LAYOUT;
 import static awais.instagrabber.utils.Constants.PREV_INSTALL_VERSION;
+import static awais.instagrabber.utils.Constants.SHOW_CAPTIONS;
 import static awais.instagrabber.utils.Constants.SHOW_QUICK_ACCESS_DIALOG;
 import static awais.instagrabber.utils.Constants.SKIPPED_VERSION;
 import static awais.instagrabber.utils.Constants.STORY_SORT;
@@ -126,7 +127,7 @@ public final class SettingsHelper {
     public @interface StringSettings {}
 
     @StringDef({DOWNLOAD_USER_FOLDER, FOLDER_SAVE_TO, AUTOPLAY_VIDEOS, SHOW_QUICK_ACCESS_DIALOG, MUTED_VIDEOS,
-                       CUSTOM_DATE_TIME_FORMAT_ENABLED, MARK_AS_SEEN, DM_MARK_AS_SEEN, CHECK_ACTIVITY,
+                       SHOW_CAPTIONS, CUSTOM_DATE_TIME_FORMAT_ENABLED, MARK_AS_SEEN, DM_MARK_AS_SEEN, CHECK_ACTIVITY,
                        CHECK_UPDATES, SWAP_DATE_TIME_FORMAT_ENABLED})
     public @interface BooleanSettings {}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="main_posts_following">%s Following </string>
     <string name="post_viewer_autoplay_video">Autoplay videos</string>
     <string name="post_viewer_muted_autoplay">Always mute videos</string>
+    <string name="post_viewer_show_captions">Always show post captions</string>
     <string name="post_viewer_download_dialog_title">Select what to download</string>
     <string name="post_viewer_download_current">Current</string>
     <string name="post_viewer_download_album">Whole Album</string>


### PR DESCRIPTION
This defaults to the current behavior of always showing the caption, but this can be turned off for reduced browsing noise: I often don't care about meaningless captions on most accounts.

Added the pref translation for French as I'm a native speaker.

[Demo video](https://user-images.githubusercontent.com/81353/104853015-6a1aa280-58fe-11eb-948f-1e512a384542.mp4). This shows in order:

1. the pref screen with the default value for the new setting
2. the behavior with the default value (true) which is the current behavior
3. toggling the setting to false
4. the new behavior which is to hide the caption when opening posts

