### PR TITLE
Increase thread message limit

### DIFF
--- a/app/src/main/java/awais/instagrabber/webservices/DirectMessagesService.java
+++ b/app/src/main/java/awais/instagrabber/webservices/DirectMessagesService.java
@@ -413,7 +413,7 @@ public class DirectMessagesService extends BaseService {
     public Call<DirectInboxResponse> fetchPendingInbox(final String cursor, final long seqId) {
         final ImmutableMap.Builder<String, Object> queryMapBuilder = ImmutableMap.<String, Object>builder()
                 .put("visual_message_return_type", "unseen")
-                .put("thread_message_limit", 10)
+                .put("thread_message_limit", 20)
                 .put("persistentBadging", true)
                 .put("limit", 10);
         if (!TextUtils.isEmpty(cursor)) {


### PR DESCRIPTION
I've had no issues going as high as 40 messages every few seconds. May make the loading time longer, though. 

I think a slider in the settings to set the thread and thread message limit would be ideal, since I rarely want to load any more than the top 2-3 threads, but it would be better to load more messages in those threads. But on my device, 10 is too low and a lot of time is spent loading old messages.