### PR TITLE
Fix emojis being url-encoded when replying to stories

### DIFF
--- a/app/src/main/java/awais/instagrabber/repositories/requests/directmessages/StoryReplyBroadcastOptions.java
+++ b/app/src/main/java/awais/instagrabber/repositories/requests/directmessages/StoryReplyBroadcastOptions.java
@@ -17,7 +17,7 @@ public class StoryReplyBroadcastOptions extends BroadcastOptions {
                                       final String reelId)
             throws UnsupportedEncodingException {
         super(clientContext, threadIdOrUserIds, BroadcastItemType.REELSHARE);
-        this.text = TextUtils.encode(text);
+        this.text = text;
         this.mediaId = mediaId;
         this.reelId = reelId; // or user id, usually same
     }

--- a/app/src/main/java/awais/instagrabber/utils/TextUtils.java
+++ b/app/src/main/java/awais/instagrabber/utils/TextUtils.java
@@ -104,18 +104,6 @@ public final class TextUtils {
         return (int) ((d2 - d1) / DateUtils.DAY_IN_MILLIS);
     }
 
-    @NonNull
-    public static String encode(final String text) throws UnsupportedEncodingException {
-        return URLEncoder.encode(text, "UTF-8")
-                         .replaceAll("\\+", "%20")
-                         .replaceAll("%21", "!")
-                         .replaceAll("%27", "'")
-                         .replaceAll("%28", "(")
-                         .replaceAll("%29", ")")
-                         .replaceAll("%7E", "~")
-                         .replaceAll("%0A", "\n");
-    }
-
     public static List<String> extractUrls(final String text) {
         if (isEmpty(text)) return Collections.emptyList();
         final Matcher matcher = Patterns.WEB_URL.matcher(text);


### PR DESCRIPTION
Currently, emojis are sent as raw, url-encoded strings. Here's a simple reproduction:

https://user-images.githubusercontent.com/11708035/109430572-618bb080-7a02-11eb-97d9-a528ae56d1f3.mp4

The fix is simply to stop url-encoding reply messages.

Now, may I ask why was this being url-encoded? I tried to send messages containing spaces, weird characters and emojis and it seems to work fine. I believe we can safely remove the encoding, although I'm concerned that there's an edge case that I'm missing.

I also removed the `encode` method as this was the only place where it was being used.

