### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,8 +12,8 @@
     <string name="clipboard_error">Error copying text</string>
     <string name="clipboard_copied">Copied to clipboard!</string>
     <string name="report">Report</string>
-    <string name="password">Password (Max 32 chars)</string>
-    <string name="set_password">Set a password (max 32 chars)</string>
+    <string name="password">Password (max 32 chars)</string>
+    <string name="set_password">Password protect (max 32 chars)</string>
     <string name="password_no_max">Password</string>
     <string name="ok">OK</string>
     <string name="yes">Yes</string>
@@ -319,9 +319,9 @@
     <string name="locations">Locations</string>
     <string name="unknown">Unknown</string>
     <string name="removed_from_favs">Removed from Favourites</string>
-    <string name="backup_and_restore">Backup &amp; Restore User Settings</string>
-    <string name="backup_summary">Back up app settings, account login information, and/or favorites data to a plain text or encrypted backup file for later restoration.</string>
-    <string name="backup_warning">If you\'re backing up login info, treat the file as confidential: Keep them somewhere safe!</string>
+    <string name="backup_and_restore">Backup &amp; Restore</string>
+    <string name="backup_summary">Backup Barinsta app settings, account login data, and/or favorites to a plain text or encrypted backup file for later restoration.</string>
+    <string name="backup_warning">If you\'re backing up account login data without password protection, treat the file as confidential and keep it somewhere safe!</string>
     <string name="create_backup">Create new backup file</string>
     <string name="restore_backup">Restore from existing backup file</string>
     <string name="file_chosen_label">File:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="clipboard_error">Error copying text</string>
     <string name="clipboard_copied">Copied to clipboard!</string>
     <string name="report">Report</string>
-    <string name="password">Password (max 32 chars)</string>
     <string name="set_password">Password protect (max 32 chars)</string>
     <string name="password_no_max">Password</string>
     <string name="ok">OK</string>
@@ -321,7 +320,7 @@
     <string name="removed_from_favs">Removed from Favourites</string>
     <string name="backup_and_restore">Backup &amp; Restore</string>
     <string name="backup_summary">Backup Barinsta app settings, account login data, and/or favorites to a plain text or encrypted backup file for later restoration.</string>
-    <string name="backup_warning">If you\'re backing up account login data without password protection, treat the file as confidential and keep it somewhere safe!</string>
+    <string name="backup_warning">If you\'re backing up account login data, treat the file as confidential and keep it somewhere safe!</string>
     <string name="create_backup">Create new backup file</string>
     <string name="restore_backup">Restore from existing backup file</string>
     <string name="file_chosen_label">File:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="clipboard_error">Error copying text</string>
     <string name="clipboard_copied">Copied to clipboard!</string>
     <string name="report">Report</string>
-    <string name="set_password">Password protect file</string>
+    <string name="set_password">Protect file with password</string>
     <string name="password_no_max">Password</string>
     <string name="ok">OK</string>
     <string name="yes">Yes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="clipboard_error">Error copying text</string>
     <string name="clipboard_copied">Copied to clipboard!</string>
     <string name="report">Report</string>
-    <string name="set_password">Password protect (max 32 chars)</string>
+    <string name="set_password">Password protect file</string>
     <string name="password_no_max">Password</string>
     <string name="ok">OK</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
Cleaned up the wording in the Backup and Restore section to make it clearer and more grammatically correct.

The only issue is I worry about is: I wonder what will happen because I extended the length of string by 2 characters for the password check mark option on line 16. Will it make the dialog wider or wrap the text? Wrapping would be ugly.

Resolves #438