### PR TITLE
Fix crashes on the story archive viewer

### DIFF
--- a/app/src/main/java/awais/instagrabber/fragments/StoryListViewerFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/StoryListViewerFragment.java
@@ -79,7 +79,7 @@ public final class StoryListViewerFragment extends Fragment implements SwipeRefr
         public void onHighlightClick(final HighlightModel model, final int position) {
             if (model == null) return;
             final NavDirections action = StoryListViewerFragmentDirections
-                    .actionStoryListFragmentToStoryViewerFragment(StoryViewerOptions.forStoryArchive(position));
+                    .actionStoryListFragmentToStoryViewerFragment(StoryViewerOptions.forStoryArchive(model.getId()));
             NavHostFragment.findNavController(StoryListViewerFragment.this).navigate(action);
         }
 

--- a/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
@@ -739,7 +739,7 @@ public class StoryViewerFragment extends Fragment {
                 final HighlightModel model = models.get(currentFeedStoryIndex);
                 currentStoryMediaId = parseStoryMediaId(model.getId());
                 currentStoryUsername = model.getTitle();
-                fetchOptions = StoryViewerOptions.forUser(Long.parseLong(currentStoryMediaId), currentStoryUsername);
+                fetchOptions = StoryViewerOptions.forStoryArchive(model.getId());
                 break;
             }
         }

--- a/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
@@ -304,11 +304,18 @@ public class StoryViewerFragment extends Fragment {
         // isNotification = fragmentArgs.getIsNotification();
         final Type type = options.getType();
         if (currentFeedStoryIndex >= 0) {
-            viewModel = type == Type.HIGHLIGHT
-                        ? type == Type.STORY_ARCHIVE
-                          ? new ViewModelProvider(fragmentActivity).get(ArchivesViewModel.class)
-                          : new ViewModelProvider(fragmentActivity).get(HighlightsViewModel.class)
-                        : new ViewModelProvider(fragmentActivity).get(FeedStoriesViewModel.class);
+            switch (type) {
+                case HIGHLIGHT:
+                    viewModel = new ViewModelProvider(fragmentActivity).get(HighlightsViewModel.class);
+                    break;
+                case STORY_ARCHIVE:
+                    viewModel = new ViewModelProvider(fragmentActivity).get(ArchivesViewModel.class);
+                    break;
+                default:
+                case FEED_STORY_POSITION:
+                    viewModel = new ViewModelProvider(fragmentActivity).get(FeedStoriesViewModel.class);
+                    break;
+            }
         }
         setupStories();
     }

--- a/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
+++ b/app/src/main/java/awais/instagrabber/fragments/StoryViewerFragment.java
@@ -65,6 +65,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import awais.instagrabber.BuildConfig;
 import awais.instagrabber.R;
@@ -735,7 +737,7 @@ public class StoryViewerFragment extends Fragment {
                     return;
                 }
                 final HighlightModel model = models.get(currentFeedStoryIndex);
-                currentStoryMediaId = model.getId();
+                currentStoryMediaId = parseStoryMediaId(model.getId());
                 currentStoryUsername = model.getTitle();
                 fetchOptions = StoryViewerOptions.forUser(Long.parseLong(currentStoryMediaId), currentStoryUsername);
                 break;
@@ -1145,5 +1147,21 @@ public class StoryViewerFragment extends Fragment {
             currentFeedStoryIndex = backward ? (currentFeedStoryIndex - 1) : (currentFeedStoryIndex + 1);
             resetView();
         }
+    }
+
+    /**
+     * Parses the Story's media ID. For user stories this is a number, but for archive stories
+     * this is "archiveDay:" plus a number.
+     */
+    private static String parseStoryMediaId(String rawId) {
+        final String regex = "(?:archiveDay:)?(.+)";
+        final Pattern pattern = Pattern.compile(regex);
+        final Matcher matcher = pattern.matcher(rawId);
+
+        if (matcher.matches() && matcher.groupCount() >= 1) {
+            return matcher.group(1);
+        }
+
+        return rawId;
     }
 }

--- a/app/src/main/java/awais/instagrabber/repositories/requests/StoryViewerOptions.java
+++ b/app/src/main/java/awais/instagrabber/repositories/requests/StoryViewerOptions.java
@@ -57,8 +57,8 @@ public class StoryViewerOptions implements Serializable {
         return new StoryViewerOptions(position, Type.FEED_STORY_POSITION);
     }
 
-    public static StoryViewerOptions forStoryArchive(final int position) {
-        return new StoryViewerOptions(position, Type.STORY_ARCHIVE);
+    public static StoryViewerOptions forStoryArchive(final String id) {
+        return new StoryViewerOptions(id, Type.STORY_ARCHIVE);
     }
 
     public long getId() {

--- a/app/src/main/java/awais/instagrabber/utils/ResponseBodyUtils.java
+++ b/app/src/main/java/awais/instagrabber/utils/ResponseBodyUtils.java
@@ -962,8 +962,7 @@ public final class ResponseBodyUtils {
     // }
 
     public static StoryModel parseStoryItem(final JSONObject data,
-                                            final boolean isLoc,
-                                            final boolean isHashtag,
+                                            final boolean isLocOrHashtag,
                                             final String username) throws JSONException {
         final boolean isVideo = data.has("video_duration");
         final StoryModel model = new StoryModel(data.getString("id"),
@@ -971,9 +970,7 @@ public final class ResponseBodyUtils {
                                                     .getString("url"), null,
                                                 isVideo ? MediaItemType.MEDIA_TYPE_VIDEO : MediaItemType.MEDIA_TYPE_IMAGE,
                                                 data.optLong("taken_at", 0),
-                                                (isLoc || isHashtag)
-                                                ? data.getJSONObject("user").getString("username")
-                                                : username,
+                                                isLocOrHashtag ? data.getJSONObject("user").getString("username") : username,
                                                 data.getJSONObject("user").getLong("pk"),
                                                 data.optBoolean("can_reply"));
 

--- a/app/src/main/java/awais/instagrabber/webservices/StoriesService.java
+++ b/app/src/main/java/awais/instagrabber/webservices/StoriesService.java
@@ -95,7 +95,7 @@ public class StoriesService extends BaseService {
                 }
                 try {
                     final JSONObject itemJson = new JSONObject(body).getJSONArray("items").getJSONObject(0);
-                    callback.onSuccess(ResponseBodyUtils.parseStoryItem(itemJson, false, false, null));
+                    callback.onSuccess(ResponseBodyUtils.parseStoryItem(itemJson, false, null));
                 } catch (JSONException e) {
                     callback.onFailure(e);
                 }
@@ -187,7 +187,7 @@ public class StoriesService extends BaseService {
                     final boolean isBestie = node.optBoolean("has_besties_media", false);
                     StoryModel firstStoryModel = null;
                     if (itemJson != null) {
-                        firstStoryModel = ResponseBodyUtils.parseStoryItem(itemJson, false, false, null);
+                        firstStoryModel = ResponseBodyUtils.parseStoryItem(itemJson, false, null);
                     }
                     feedStoryModels.add(new FeedStoryModel(id, user, fullyRead, timestamp, firstStoryModel, mediaCount, false, isBestie));
                 }
@@ -364,9 +364,8 @@ public class StoriesService extends BaseService {
                              final ServiceCallback<List<StoryModel>> callback) {
         final String url = buildUrl(options);
         final Call<String> userStoryCall = repository.getUserStory(url);
-        final boolean isLoc = options.getType() == StoryViewerOptions.Type.LOCATION;
-        final boolean isHashtag = options.getType() == StoryViewerOptions.Type.HASHTAG;
-        final boolean isHighlight = options.getType() == StoryViewerOptions.Type.HIGHLIGHT;
+        final boolean isLocOrHashtag = options.getType() == StoryViewerOptions.Type.LOCATION || options.getType() == StoryViewerOptions.Type.HASHTAG;
+        final boolean isHighlight = options.getType() == StoryViewerOptions.Type.HIGHLIGHT || options.getType() == StoryViewerOptions.Type.STORY_ARCHIVE;
         userStoryCall.enqueue(new Callback<String>() {
             @Override
             public void onResponse(@NonNull final Call<String> call, @NonNull final Response<String> response) {
@@ -380,7 +379,7 @@ public class StoriesService extends BaseService {
                     data = new JSONObject(body);
 
                     if (!isHighlight) {
-                        data = data.optJSONObject((isLoc || isHashtag) ? "story" : "reel");
+                        data = data.optJSONObject((isLocOrHashtag) ? "story" : "reel");
                     } else {
                         data = data.getJSONObject("reels").optJSONObject(options.getName());
                     }
@@ -388,8 +387,7 @@ public class StoriesService extends BaseService {
                     String username = null;
                     if (data != null
                             // && localUsername == null
-                            && !isLoc
-                            && !isHashtag) {
+                            && !isLocOrHashtag) {
                         username = data.getJSONObject("user").getString("username");
                     }
 
@@ -397,12 +395,11 @@ public class StoriesService extends BaseService {
                     if (data != null
                             && (media = data.optJSONArray("items")) != null
                             && media.length() > 0 && media.optJSONObject(0) != null) {
-
                         final int mediaLen = media.length();
                         final List<StoryModel> models = new ArrayList<>();
                         for (int i = 0; i < mediaLen; ++i) {
                             data = media.getJSONObject(i);
-                            models.add(ResponseBodyUtils.parseStoryItem(data, isLoc, isHashtag, username));
+                            models.add(ResponseBodyUtils.parseStoryItem(data, isLocOrHashtag, username));
                         }
                         callback.onSuccess(models);
                     } else {
@@ -543,6 +540,7 @@ public class StoriesService extends BaseService {
                 id = String.valueOf(options.getId());
                 break;
             case HIGHLIGHT:
+            case STORY_ARCHIVE:
                 builder.append("feed/reels_media/?user_ids=");
                 id = options.getName();
                 break;
@@ -550,15 +548,12 @@ public class StoriesService extends BaseService {
                 break;
             // case FEED_STORY_POSITION:
             //     break;
-            // case STORY_ARCHIVE:
-            //     break;
         }
         if (id == null) {
             return null;
         }
-        final String userId = id.replace(":", "%3A");
-        builder.append(userId);
-        if (type != StoryViewerOptions.Type.HIGHLIGHT) {
+        builder.append(id);
+        if (type != StoryViewerOptions.Type.HIGHLIGHT && type != StoryViewerOptions.Type.STORY_ARCHIVE) {
             builder.append("/story/");
         }
         return builder.toString();


### PR DESCRIPTION
This PR fixes two crashes on the story archive viewer. However, it does not make the `StoryViewerFragment` display the actual content, it simply prevents the app from crashing.

The first crash was caused because on `StoryViewerFragment#init`, the `HighlightsViewModel` was being created instead of the proper `ArchivesViewModel`.

I've taken the liberty to refactor this code to a switch statement as it feels more readable to me. Personally I believe that nested ternaries are a no-no for maintainability, and in fact I didn't fully understand this ternary when refactoring (the first condition `type == Type.HIGHLIGHT` was false and the second `type == Type.STORY_ARCHIVE` was true, and yet the branch taken was that of `new ViewModelProvider(fragmentActivity).get(HighlightsViewModel.class)` - what the hell?). I couldn't find an explanation, I merely refactored the code so please let me know if I missed something.

As for the second crash I handled the case when Instagram was seding IDs of the type `archiveDay:17861826641451806` instead of simply `17861826641451806`, thus the conversion to long was failing. Now I don't know if we actually have to use `archiveDay:17861826641451806` or `17861826641451806` with the API (in the first case we would have to store the whole ID and not just take the number). I don't know why this was not being handled before, maybe Insta modified their APIs?

Finally, while this PR fixes both crashes, it does not make the stories archive usable. I have found that when you view an user's story the URL called is:

`https://i.instagram.com/api/v1/feed/user/123/story/` where 123 is the user's ID.

But when you view your own archive the URL called is:

`https://i.instagram.com/api/v1/feed/user/987/story/` where 987 is the story's ID. This request fails with 400:

```json
{
  "message": "Invalid target user.",
  "status": "fail"
}
```

It seems to me that the problem is that the [`StoriesService#buildUrl`](https://github.com/austinhuang0131/barinsta/blob/358beffa9dbcf5d8eec669d6a45e746aaa18a4c4/app/src/main/java/awais/instagrabber/webservices/StoriesService.java#L527) method doesn't handle the case of `STORY_ARCHIVE` properly. I could use your input here @austinhuang0131 :smile: 