### PR TITLE
Add ability to use login links to add accounts

### DIFF
--- a/app/src/main/java/awais/instagrabber/activities/Login.java
+++ b/app/src/main/java/awais/instagrabber/activities/Login.java
@@ -1,6 +1,9 @@
 package awais.instagrabber.activities;
 
 import android.annotation.SuppressLint;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Build;
@@ -9,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.URLUtil;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -23,6 +27,8 @@ import awais.instagrabber.databinding.ActivityLoginBinding;
 import awais.instagrabber.utils.Constants;
 import awais.instagrabber.utils.CookieUtils;
 import awais.instagrabber.utils.TextUtils;
+
+import static android.content.ClipDescription.MIMETYPE_TEXT_PLAIN;
 
 public final class Login extends BaseLanguageActivity implements View.OnClickListener, CompoundButton.OnCheckedChangeListener {
     private final WebViewClient webViewClient = new WebViewClient() {
@@ -68,12 +74,32 @@ public final class Login extends BaseLanguageActivity implements View.OnClickLis
         loginBinding.desktopMode.setOnCheckedChangeListener(this);
         loginBinding.cookies.setOnClickListener(this);
         loginBinding.refresh.setOnClickListener(this);
+        loginBinding.pasteLoginLink.setOnClickListener(this);
+
     }
 
     @Override
     public void onClick(final View v) {
         if (v == loginBinding.refresh) {
             loginBinding.webView.loadUrl("https://instagram.com/");
+            return;
+        }
+        if (v == loginBinding.pasteLoginLink) {
+            ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+            if (clipboard.hasPrimaryClip() && clipboard.getPrimaryClip() != null && clipboard.getPrimaryClipDescription().hasMimeType(MIMETYPE_TEXT_PLAIN)) {
+                ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
+                if (item != null) {
+                    CharSequence loginLink = item.getText();
+                    if (!TextUtils.isEmpty(loginLink)) {
+                        String loginLinkString = loginLink.toString();
+                        if (URLUtil.isValidUrl(loginLinkString)) {
+                            loginBinding.webView.loadUrl(loginLinkString);
+                            return;
+                        }
+                    }
+                }
+            }
+            Toast.makeText(this, getString(R.string.login_invalid_url), Toast.LENGTH_SHORT).show();
             return;
         }
         if (v == loginBinding.cookies) {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -41,5 +41,14 @@
             android:layout_weight="1"
             android:gravity="center"
             android:text="@string/desktop_2fa" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/paste_login_link"
+            style="@style/Widget.AppCompat.Button.ButtonBar.AlertDialog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Paste login link" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -49,6 +49,6 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="center"
-            android:text="Paste login link" />
+            android:text="@string/paste_login_link" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -48,7 +48,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:gravity="center"
+            android:layout_gravity="center"
             android:text="@string/paste_login_link" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,5 +486,5 @@
     <string name="copy_caption">Copy caption</string>
     <string name="copy_reply">Copy reply</string>
     <string name="login_invalid_url">Please copy a valid login link</string>
-    <string name="paste_login_link">Paste login link</string>
+    <string name="paste_login_link">Paste ig.me login link</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -485,4 +485,5 @@
     <string name="dm_remove_warning">If saved, all DM related features will be disabled on next launch</string>
     <string name="copy_caption">Copy caption</string>
     <string name="copy_reply">Copy reply</string>
+    <string name="login_invalid_url">Please copy a valid login link</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,4 +486,5 @@
     <string name="copy_caption">Copy caption</string>
     <string name="copy_reply">Copy reply</string>
     <string name="login_invalid_url">Please copy a valid login link</string>
+    <string name="paste_login_link">Paste login link</string>
 </resources>


### PR DESCRIPTION
Hi

Thanks for the awesome app! I just found it on F-droid and I am really stoked about it. Unfortunately, my Instagram account doesn't have a password (for some reason). I can only login through "login links" or using Facebook. 

This pull request adds the ability to use login links to add accounts. Those links are sent to you via sms and can log you in directly without password, through your default web browser, thus bypassing barinsta webview. This pull-request fixes this issue by allowing the user to paste the link into barinsta.

Maybe as a suggestion, barinsta should directly handle https://ig.me links

Thank you

