### PR TITLE
Corrected URL typos for ToS and Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For documentation, visit [Barinsta.AustinHuang.me](https://barinsta.austinhuang.
 
 ## Download
 
-**By installing, you indicate your acceptance of [Terms of Service](https://barinsta.austinhuang.me/en/latest/tos/) and [Privacy Policy](https://barinsta.austinhuang.me/en/latest/privacy/).**
+**By installing, you indicate your acceptance of [Terms of Service](https://barinsta.austinhuang.me/en/latest/tos.html) and [Privacy Policy](https://barinsta.austinhuang.me/en/latest/privacy.html).**
 
 <a href="https://f-droid.org/en/packages/me.austinhuang.instagrabber/"><img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="75"></a>
 <a href="https://github.com/austinhuang0131/barinsta/releases/latest"><img src="https://raw.githubusercontent.com/andOTP/andOTP/master/assets/badges/get-it-on-github.png" height="75"></a>


### PR DESCRIPTION
The Markdown URLs for the ToS and Privacy currently lead to not found/404 pages because of missing suffixes of `.html`.  With the edits, the 2 respective links for the ToS and Privacy pages should be working properly now.